### PR TITLE
expose the rewind state and add finished function to SoundInstance

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -188,6 +188,11 @@ impl SoundInstance {
     pub fn toggle_repeating(&self) {
         self.controls.set_repeating(!self.controls.repeating());
     }
+    
+    /// return true when playback is finished
+    pub fn finished(&self) -> bool{
+        self.controls.finished()
+    }
 }
 
 // TODO: Remove or make more useful in 0.4.

--- a/src/platform/audio_rodio.rs
+++ b/src/platform/audio_rodio.rs
@@ -47,6 +47,10 @@ impl AudioControls {
     pub fn set_repeating(&self, repeating: bool) {
         self.repeating.store(repeating, Ordering::SeqCst);
     }
+    
+    pub fn finished(&self) -> bool{
+        self.rewind.load(Ordering::SeqCst)
+    }
 }
 
 pub struct AudioDevice {


### PR DESCRIPTION
For sound that does not loop it is important to know when it has finished playing.
This allows the following sound to be played or game events to be coordinated.

I used it in the latest game to play the background music again after a certain time.
